### PR TITLE
Update updater: Update in-memory items in #update

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -31,7 +31,11 @@ module Spree
     end
 
     def recalculate_adjustments
-      all_adjustments.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
+      adjustables = [*line_items, *shipments, order]
+
+      adjustables.each do |adjustable|
+        Spree::ItemAdjustments.new(adjustable).update
+      end
     end
 
     # Updates the following Order total values:

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -47,6 +47,7 @@ module Spree
           updater.update
           create(:adjustment, source: promotion_action, adjustable: order, order: order)
           create(:line_item, order: order, price: 10) # in addition to the two already created
+          order.line_items.reload # need to pick up the extra line item
           updater.update
         end
 


### PR DESCRIPTION
Addresses https://github.com/solidusio/solidus/pull/1389#discussion_r74974354

So that any already-loaded line item or shipment objects will be
updated.  This is to make it more likely that code like this:

```
order.update!
order.line_items.each { ... }
```

will have the correct data without having to issue an `order.reload`
after the `order.update!`.
